### PR TITLE
Add Support for Evaluating models on HuggingFace Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,32 @@
 `t2i_diffusion_benchmark` is a library for performing comprehensive benchmark of text-to-image diffusion models on image quality and prompt comprehension integrated with [Weights & Biases](https://wandb.ai/site) and [Weave](https://wandb.github.io/weave/).
 
 ```python
-from t2i_diffusion_benchmark.metrics import CLIPImageQualityScorer, CLIPScorer
+from t2i_diffusion_benchmark.metrics import (
+    CLIPImageQualityScorer,
+    CLIPScorer,
+    BLIPScorer,
+)
 from t2i_diffusion_benchmark.eval_pipelines import StableDiffusionEvaluationPipeline
 
 
-if __name__ == "__main__":
-    dataset = [
-        {"prompt": "a photo of an astronaut riding a horse on mars"},
-        {"prompt": "A high tech solarpunk utopia in the Amazon rainforest"},
-        {"prompt": "A pikachu fine dining with a view to the Eiffel Tower"},
-        {"prompt": "A mecha robot in a favela in expressionist style"},
-        {"prompt": "an insect robot preparing a delicious meal"},
-        {
-            "prompt": "A small cabin on top of a snowy mountain in the style of Disney, artstation"
-        },
-    ]
+diffuion_evaluation_pipeline = StableDiffusionEvaluationPipeline(
+    "CompVis/stable-diffusion-v1-4"
+)
 
-    diffuion_evaluation_pipeline = StableDiffusionEvaluationPipeline(
-        "CompVis/stable-diffusion-v1-4"
-    )
+# Add CLIP Scorer metric
+clip_scorer = CLIPScorer()
+diffuion_evaluation_pipeline.add_metric(clip_scorer)
 
-    # Add CLIP Scorer metric
-    clip_scorer = CLIPScorer()
-    diffuion_evaluation_pipeline.add_metric(clip_scorer)
+# Add CLIP IQA Metric
+clip_iqa_scorer = CLIPImageQualityScorer()
+diffuion_evaluation_pipeline.add_metric(clip_iqa_scorer)
 
-    # Add CLIP IQA Metric
-    clip_iqa_scorer = CLIPImageQualityScorer()
-    diffuion_evaluation_pipeline.add_metric(clip_iqa_scorer)
+# Add BLIP Scorer Metric
+blip_scorer = BLIPScorer()
+diffuion_evaluation_pipeline.add_metric(blip_scorer)
 
-    diffuion_evaluation_pipeline(
-        dataset=dataset, init_params=dict(project="t2i_eval", entity="geekyrakshit")
-    )
+diffuion_evaluation_pipeline(
+    dataset="parti-prompts:v1",
+    init_params=dict(project="t2i_eval", entity="geekyrakshit"),
+)
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -838,6 +838,20 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", 
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
+name = "fire"
+version = "0.6.0"
+description = "A library for automatically generating command line interfaces."
+optional = false
+python-versions = "*"
+files = [
+    {file = "fire-0.6.0.tar.gz", hash = "sha256:54ec5b996ecdd3c0309c800324a0703d6da512241bc73b553db959d98de0aa66"},
+]
+
+[package.dependencies]
+six = "*"
+termcolor = "*"
+
+[[package]]
 name = "frozenlist"
 version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -3097,6 +3111,20 @@ files = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "2.4.0"
+description = "ANSI color formatting for output in terminal"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "termcolor-2.4.0-py3-none-any.whl", hash = "sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63"},
+    {file = "termcolor-2.4.0.tar.gz", hash = "sha256:aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a"},
+]
+
+[package.extras]
+tests = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "tiktoken"
 version = "0.6.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
@@ -3745,4 +3773,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "19a6277979c4886333b85ab737406f298eca267b2658f26426f22b0f5ec466b9"
+content-hash = "10a4e3a0fe9dc80b52f623085cf26df6504eaa5f9491e88d1965ae67a1038e60"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ poetry = "^1.8.3"
 weave = "^0.50.2"
 huggingface-hub = "^0.23.0"
 datasets = "^2.19.1"
+fire = "^0.6.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/evaluate_weave.py
+++ b/scripts/evaluate_weave.py
@@ -7,32 +7,23 @@ from t2i_diffusion_benchmark.eval_pipelines import StableDiffusionEvaluationPipe
 
 
 if __name__ == "__main__":
-    dataset = [
-        {"prompt": "a photo of an astronaut riding a horse on mars"},
-        {"prompt": "A high tech solarpunk utopia in the Amazon rainforest"},
-        # {"prompt": "A pikachu fine dining with a view to the Eiffel Tower"},
-        # {"prompt": "A mecha robot in a favela in expressionist style"},
-        # {"prompt": "an insect robot preparing a delicious meal"},
-        # {
-        #     "prompt": "A small cabin on top of a snowy mountain in the style of Disney, artstation"
-        # },
-    ]
-
     diffuion_evaluation_pipeline = StableDiffusionEvaluationPipeline(
         "CompVis/stable-diffusion-v1-4"
     )
 
-    # # Add CLIP Scorer metric
-    # clip_scorer = CLIPScorer()
-    # diffuion_evaluation_pipeline.add_metric(clip_scorer)
+    # Add CLIP Scorer metric
+    clip_scorer = CLIPScorer()
+    diffuion_evaluation_pipeline.add_metric(clip_scorer)
 
-    # # Add CLIP IQA Metric
-    # clip_iqa_scorer = CLIPImageQualityScorer()
-    # diffuion_evaluation_pipeline.add_metric(clip_iqa_scorer)
+    # Add CLIP IQA Metric
+    clip_iqa_scorer = CLIPImageQualityScorer()
+    diffuion_evaluation_pipeline.add_metric(clip_iqa_scorer)
 
+    # Add BLIP Scorer Metric
     blip_scorer = BLIPScorer()
     diffuion_evaluation_pipeline.add_metric(blip_scorer)
 
     diffuion_evaluation_pipeline(
-        dataset=dataset, init_params=dict(project="t2i_eval", entity="geekyrakshit")
+        dataset="parti-prompts:v1",
+        init_params=dict(project="t2i_eval", entity="geekyrakshit"),
     )

--- a/scripts/evaluate_weave.py
+++ b/scripts/evaluate_weave.py
@@ -1,4 +1,8 @@
-from t2i_diffusion_benchmark.metrics import CLIPImageQualityScorer, CLIPScorer
+from t2i_diffusion_benchmark.metrics import (
+    CLIPImageQualityScorer,
+    CLIPScorer,
+    BLIPScorer,
+)
 from t2i_diffusion_benchmark.eval_pipelines import StableDiffusionEvaluationPipeline
 
 
@@ -6,25 +10,28 @@ if __name__ == "__main__":
     dataset = [
         {"prompt": "a photo of an astronaut riding a horse on mars"},
         {"prompt": "A high tech solarpunk utopia in the Amazon rainforest"},
-        {"prompt": "A pikachu fine dining with a view to the Eiffel Tower"},
-        {"prompt": "A mecha robot in a favela in expressionist style"},
-        {"prompt": "an insect robot preparing a delicious meal"},
-        {
-            "prompt": "A small cabin on top of a snowy mountain in the style of Disney, artstation"
-        },
+        # {"prompt": "A pikachu fine dining with a view to the Eiffel Tower"},
+        # {"prompt": "A mecha robot in a favela in expressionist style"},
+        # {"prompt": "an insect robot preparing a delicious meal"},
+        # {
+        #     "prompt": "A small cabin on top of a snowy mountain in the style of Disney, artstation"
+        # },
     ]
 
     diffuion_evaluation_pipeline = StableDiffusionEvaluationPipeline(
         "CompVis/stable-diffusion-v1-4"
     )
 
-    # Add CLIP Scorer metric
-    clip_scorer = CLIPScorer()
-    diffuion_evaluation_pipeline.add_metric(clip_scorer)
+    # # Add CLIP Scorer metric
+    # clip_scorer = CLIPScorer()
+    # diffuion_evaluation_pipeline.add_metric(clip_scorer)
 
-    # Add CLIP IQA Metric
-    clip_iqa_scorer = CLIPImageQualityScorer()
-    diffuion_evaluation_pipeline.add_metric(clip_iqa_scorer)
+    # # Add CLIP IQA Metric
+    # clip_iqa_scorer = CLIPImageQualityScorer()
+    # diffuion_evaluation_pipeline.add_metric(clip_iqa_scorer)
+
+    blip_scorer = BLIPScorer()
+    diffuion_evaluation_pipeline.add_metric(blip_scorer)
 
     diffuion_evaluation_pipeline(
         dataset=dataset, init_params=dict(project="t2i_eval", entity="geekyrakshit")

--- a/scripts/publish_dataset.py
+++ b/scripts/publish_dataset.py
@@ -1,0 +1,25 @@
+import weave
+from fire import Fire
+from t2i_diffusion_benchmark.utils import publish_prompt_dataset_to_weave
+
+
+def publish(
+    project_name: str,
+    dataset_path: str,
+    dataset_name: str,
+    prompt_column: str,
+    split: str,
+    data_limit: int,
+):
+    weave.init(project_name=project_name)
+    publish_prompt_dataset_to_weave(
+        dataset_path=dataset_path,
+        dataset_name=dataset_name,
+        prompt_column=prompt_column,
+        split=split,
+        data_limit=data_limit,
+    )
+
+
+if __name__ == "__main__":
+    Fire(publish)

--- a/t2i_diffusion_benchmark/eval_pipelines/stable_diffusion_evaluation.py
+++ b/t2i_diffusion_benchmark/eval_pipelines/stable_diffusion_evaluation.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 
 import torch
 from diffusers import StableDiffusionPipeline
@@ -88,8 +88,9 @@ class StableDiffusionEvaluationPipeline:
             self.wandb_table.add_data(*current_row)
         wandb.log({"Evalution": self.wandb_table})
 
-    def __call__(self, dataset: Dict, init_params: Dict):
+    def __call__(self, dataset: Union[Dict, str], init_params: Dict):
         weave.init(project_name="t2i_eval")
+        dataset = weave.ref(dataset).get() if isinstance(dataset, str) else dataset
         evaluation = Evaluation(
             dataset=dataset,
             scorers=[metric_fn.__call__ for metric_fn in self.metric_functions],

--- a/t2i_diffusion_benchmark/metrics/__init__.py
+++ b/t2i_diffusion_benchmark/metrics/__init__.py
@@ -1,3 +1,3 @@
-from .image_quality_scorers import CLIPImageQualityScorer, CLIPScorer
+from .image_quality_scorers import CLIPImageQualityScorer, CLIPScorer, BLIPScorer
 
-__all__ = ["CLIPImageQualityScorer", "CLIPScorer"]
+__all__ = ["CLIPImageQualityScorer", "CLIPScorer", "BLIPScorer"]

--- a/t2i_diffusion_benchmark/metrics/image_quality_scorers.py
+++ b/t2i_diffusion_benchmark/metrics/image_quality_scorers.py
@@ -9,7 +9,9 @@ import numpy as np
 import weave
 
 import torch
+from torch.nn import functional as F
 from torchmetrics.functional.multimodal import clip_score, clip_image_quality_assessment
+from transformers import BlipForConditionalGeneration, BlipProcessor
 
 
 class CLIPScorer:
@@ -94,3 +96,55 @@ class CLIPImageQualityScorer:
             score_dict[f"{self.name}_{prompt}"] = clip_iqa_score
         self.scores.append(score_dict)
         return score_dict
+
+
+class BLIPScorer:
+    def __init__(
+        self,
+        blip_model_name_or_path: str = "Salesforce/blip-image-captioning-base",
+        name: str = "blip_score",
+        device: str = "cuda",
+    ) -> None:
+        self.scores = []
+        self.name = name
+        self.device = device
+        self.blip_processor = BlipProcessor.from_pretrained(blip_model_name_or_path)
+        self.blip_model = BlipForConditionalGeneration.from_pretrained(
+            blip_model_name_or_path
+        ).to(self.device)
+        self.config = {"blip_model_name_or_path": blip_model_name_or_path}
+
+    def compute_blip_score(self, prompt: str, pil_image: Image.Image):
+        pixel_values = self.blip_processor(
+            images=pil_image, return_tensors="pt"
+        ).pixel_values
+        text_input_ids = self.blip_processor(
+            text=prompt, return_tensors="pt", padding=True, truncation=True
+        ).input_ids
+        outputs = self.blip_model(
+            pixel_values=pixel_values.to(self.device),
+            input_ids=text_input_ids.to(self.device),
+        )
+        logits = outputs.logits[:, :-1, :]
+        shift_labels = text_input_ids[..., 1:].contiguous()
+        blip_score = float(
+            F.cross_entropy(
+                logits.view(-1, logits.size(-1)).to(self.device),
+                shift_labels.view(-1).to(self.device),
+            )
+            .detach()
+            .item()
+        )
+        return blip_score
+
+    @weave.op()
+    async def __call__(
+        self, prompt: str, model_output: Dict[str, Any] = None
+    ) -> Dict[str, float]:
+        pil_image = Image.open(
+            BytesIO(base64.b64decode(model_output["image"].split(";base64,")[-1]))
+        )
+        blip_score = self.compute_blip_score(prompt, pil_image)
+        print(f"{blip_score=}")
+        self.scores.append(blip_score)
+        return {self.name: blip_score}

--- a/t2i_diffusion_benchmark/utils.py
+++ b/t2i_diffusion_benchmark/utils.py
@@ -34,9 +34,10 @@ def image_to_data_url(file_path):
     return data_url
 
 
-def publish_dataset_to_weave(
+def publish_prompt_dataset_to_weave(
     dataset_path,
     dataset_name: str,
+    prompt_column: str,
     split: Optional[str] = None,
     data_limit: Optional[int] = None,
     get_weave_dataset_reference: bool = True,
@@ -51,10 +52,9 @@ def publish_dataset_to_weave(
         if data_limit is not None and data_limit < len(dataset_dict)
         else dataset_dict
     )
+    dataset_dict = dataset_dict.rename_column(prompt_column, "prompt")
     weave_dataset_rows = []
-    print(f"{dataset_dict[0]=}")
     for data_item in tqdm(dataset_dict):
-        print(f"{data_item=}")
         for keys in data_item.keys():
             data_item[keys] = (
                 column_transforms[keys](data_item[keys])

--- a/t2i_diffusion_benchmark/utils.py
+++ b/t2i_diffusion_benchmark/utils.py
@@ -2,6 +2,12 @@ import base64
 import io
 from PIL import Image
 from pathlib import Path
+from typing import Callable, Dict, Optional, Union
+
+import weave
+from datasets import load_dataset
+from tqdm.auto import tqdm
+from weave.trace.refs import ObjectRef
 
 
 EXT_TO_MIMETYPE = {
@@ -26,3 +32,36 @@ def image_to_data_url(file_path):
 
     data_url = f"data:{mimetype};base64,{encoded_string}"
     return data_url
+
+
+def publish_dataset_to_weave(
+    dataset_path,
+    dataset_name: str,
+    split: Optional[str] = None,
+    data_limit: Optional[int] = None,
+    get_weave_dataset_reference: bool = True,
+    column_transforms: Optional[Dict[str, Callable]] = None,
+    *args,
+    **kwargs,
+) -> Union[ObjectRef, None]:
+    dataset_dict = load_dataset(dataset_path, *args, **kwargs)
+    dataset_dict = dataset_dict[split] if split else dataset_dict["train"]
+    dataset_dict = (
+        dataset_dict.take(data_limit)
+        if data_limit is not None and data_limit < len(dataset_dict)
+        else dataset_dict
+    )
+    weave_dataset_rows = []
+    print(f"{dataset_dict[0]=}")
+    for data_item in tqdm(dataset_dict):
+        print(f"{data_item=}")
+        for keys in data_item.keys():
+            data_item[keys] = (
+                column_transforms[keys](data_item[keys])
+                if column_transforms
+                else data_item[keys]
+            )
+        weave_dataset_rows.append(data_item)
+    weave_dataset = weave.Dataset(name=dataset_name, rows=weave_dataset_rows)
+    weave.publish(weave_dataset)
+    return weave.ref(dataset_name).get() if get_weave_dataset_reference else None


### PR DESCRIPTION
This PR adds support for publishing prompt-based datasets from HuggingFace Hub, such as [nateraw/parti-prompts](https://huggingface.co/datasets/nateraw/parti-prompts) and evaluating using the evaluation pipelines.